### PR TITLE
It's better we support specifying registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ var getPkg = require('get-pkg');
 getPkg('generate', function(err, pkg) {
   console.log(pkg);
 });
+
+//specify a registry
+getPkg('generate', {
+  registry: 'https://registry.npm.taobao.org/'
+}, function(err, pkg) {
+  console.log(pkg);
+});
 ```
 
 ## Related projects

--- a/index.js
+++ b/index.js
@@ -9,21 +9,33 @@
 
 var request = require('min-request');
 
-module.exports = function getPkg(name, version, cb) {
-  if (typeof version === 'function') {
-    cb = version;
-    version = '';
+var OFFICIAL_REGISTRY = 'https://registry.npmjs.org/';
+
+module.exports = function getPkg(name, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {
+      version: '',
+      registry: OFFICIAL_REGISTRY
+    };
   }
+
+  if (!opts.registry) {
+    opts.registry = OFFICIAL_REGISTRY;
+  } else if (opts.registry.lastIndexOf('/') !== opts.registry.length - 1) {
+    opts.registry = opts.registry + '/';
+  }
+
   if (isScoped(name)) {
     name = '@' + encodeURIComponent(name.slice(1));
-    version = ''; // npm does not allow version for scoped packages
-  } else if (!version) {
-    version = 'latest';
+    opts.version = ''; // npm does not allow version for scoped packages
+  } else if (!opts.version) {
+    opts.version = 'latest';
   }
 
-  var url = 'https://registry.npmjs.org/' + name + '/';
+  var url = opts.registry + name + '/';
 
-  request(url + version, {}, function(err, res) {
+  request(url + opts.version, {}, function(err, res) {
     if (err) return cb(err);
     if (res.statusCode === 500) {
       return cb(new Error(res.statusMessage));

--- a/test.js
+++ b/test.js
@@ -45,4 +45,17 @@ describe('getPackages', function() {
       cb();
     });
   });
+
+  it('should handle specific registry', function(cb) {
+    getPkg('angular', {
+      registry: 'https://registry.npm.taobao.org/'
+    }, function(err, pkg) {
+      assert(!err);
+      assert(pkg);
+      assert.equal(pkg.name, 'angular');
+      cb();
+    });
+  });
+
+
 });


### PR DESCRIPTION
Because i am setting up a private registry for my company, therefor, i need the package information shall be retrieved from it instead of `https://registry.npmjs.org/`