### PR TITLE
fix: make get-pkg working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/actual
 tmp
 TODO.md
 vendor
+/package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "5"
   - "4"
   - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "stable"
   - "5"
   - "4"
-  - "0.12"
 matrix:
   fast_finish: true
   allow_failures:

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 /*!
  * get-pkgs <https://github.com/jonschlinkert/get-pkgs>
  *
- * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Copyright (c) 2014-present, Jon Schlinkert.
  * Licensed under the MIT License.
  */
 
 'use strict';
 
-var request = require('min-request');
+const request = require('axios');
 
 module.exports = function getPkg(name, version, cb) {
   if (typeof version === 'function') {
@@ -21,25 +21,24 @@ module.exports = function getPkg(name, version, cb) {
     version = 'latest';
   }
 
-  var url = 'https://registry.npmjs.org/' + name + '/';
+  const url = 'https://registry.npmjs.org/' + name + '/';
 
-  request(url + version, {}, function(err, res) {
-    if (err) return cb(err);
-    if (res.statusCode === 500) {
-      return cb(new Error(res.statusMessage));
-    }
-    if (res.statusCode === 404) {
-      var error = new Error('document not found');
-      error.code = res.statusCode;
-      error.pkgName = name;
-      return cb(error);
-    }
-    var pkg = JSON.parse(res.body);
-    if (pkg.error && pkg.reason) {
-      return cb(new Error(pkg.reason));
-    }
-    cb(null, pkg);
-  });
+  request.get(url + version)
+    .then(function(res) {
+      cb(null, res.data);
+    })
+    .catch(function(err) {
+      if (err.response.status === 500) {
+        return cb(new Error(err.response.status));
+      }
+      if (err.response.status === 404) {
+        const error = new Error('document not found');
+        error.code = err.response.status;
+        error.pkgName = name;
+        return cb(error);
+      }
+      return cb(err);
+    });
 };
 
 function isScoped(name) {

--- a/package.json
+++ b/package.json
@@ -1,31 +1,7 @@
 {
   "name": "get-pkg",
-  "description": "Get the package.json for a project from npm.",
   "version": "0.3.0",
-  "homepage": "https://github.com/jonschlinkert/get-pkg",
-  "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
-  "repository": "jonschlinkert/get-pkg",
-  "bugs": {
-    "url": "https://github.com/jonschlinkert/get-pkg/issues"
-  },
-  "license": "MIT",
-  "files": [
-    "index.js"
-  ],
-  "main": "index.js",
-  "engines": {
-    "node": ">=0.10.0"
-  },
-  "scripts": {
-    "test": "mocha"
-  },
-  "dependencies": {
-    "min-request": "^1.4.1"
-  },
-  "devDependencies": {
-    "gulp-format-md": "^0.1.7",
-    "mocha": "^2.4.5"
-  },
+  "description": "Get the package.json for a project from npm.",
   "keywords": [
     "get",
     "json",
@@ -37,6 +13,30 @@
     "pkg",
     "pkgs"
   ],
+  "homepage": "https://github.com/jonschlinkert/get-pkg",
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/get-pkg/issues"
+  },
+  "license": "MIT",
+  "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
+  "files": [
+    "index.js"
+  ],
+  "main": "index.js",
+  "repository": "jonschlinkert/get-pkg",
+  "scripts": {
+    "test": "mocha"
+  },
+  "dependencies": {
+    "axios": "^0.18.0"
+  },
+  "devDependencies": {
+    "gulp-format-md": "^0.1.7",
+    "mocha": "^2.4.5"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "verb": {
     "run": true,
     "toc": false,

--- a/test.js
+++ b/test.js
@@ -8,8 +8,8 @@
 'use strict';
 
 require('mocha');
-var assert = require('assert');
-var getPkg = require('./');
+const assert = require('assert');
+const getPkg = require('./');
 
 describe('getPackages', function() {
   it('should get a package.json for the given project', function(cb) {
@@ -22,15 +22,18 @@ describe('getPackages', function() {
   });
 
   it('should handle errors', function(cb) {
-    getPkg('fofofofofofoofofof', function(err, pkg) {
+    getPkg('fofofofofofoofofof', function(err /*, pkg */) {
       assert(err);
       assert.equal(err.message, 'document not found');
       cb();
     });
   });
 
-  it('should handle empty string', function(cb) {
-    getPkg('', function(err, pkg) {
+  // Deactivated: Seems that the npm implementation has changed.
+  // In case an empty string is passed to npm, npm return the latest
+  // available package, so this test does not make to make sense anymore.
+  xit('should handle empty string', function(cb) {
+    getPkg('', function(err /*, pkg */) {
       assert(err);
       assert.equal(err.message, 'Internal Server Error');
       cb();


### PR DESCRIPTION
The implementation of npm has changed in several way, which results into this repository to be broken.
Basically this also results into verb-generate-readme to be broken.

This PR offers a solution, actually getting the scope of `get-pkg` to work again.
Note, there is one test, I have deactivated ("should handle empty string"), as it does not make sense anymore based on the changes npm has introduced.

Travis CI tests:
- I have removed the requirement to be able to successfully run on < v4 of node.js, which is really very old
